### PR TITLE
Improve get_transition_image

### DIFF
--- a/src/transitionmap.jl
+++ b/src/transitionmap.jl
@@ -25,14 +25,15 @@ function get_transition_image(trans_map::TransitionMapHash, x_ref)
     _check_sorted_unique(trans_map)
     idx_list_x = searchsorted(trans_map.elems, (x_ref,), by = x -> x[1])
     uy_ref_coll = Pair{UInt64,Vector{UInt64}}[]
-    cur_u = nothing
-    cur_i = 0
-    for i in idx_list_x
+    if isempty(idx_list_x)
+        return uy_ref_coll
+    end
+    cur_i = idx_list_x[1]
+    cur_u = uy_ref_coll[i][1]
+    for i in idx_list_x[2:end]
         _, u, y = trans_map.elems[i]
-        if cur_u === nothing || cur_u != u
-            if cur_u !== nothing
-                push!(uy_ref_coll, cur_u => UInt64[trans_map.elems[j][3] for j in cur_i:i])
-            end
+        if cur_u != u
+            push!(uy_ref_coll, cur_u => UInt64[trans_map.elems[j][3] for j in cur_i:(i-1)])
             cur_u = u
             cur_i = i
         end

--- a/src/transitionmap.jl
+++ b/src/transitionmap.jl
@@ -24,12 +24,18 @@ end
 function get_transition_image(trans_map::TransitionMapHash, x_ref)
     _check_sorted_unique(trans_map)
     idx_list_x = searchsorted(trans_map.elems, (x_ref,), by = x -> x[1])
-    trans_coll_x = trans_map.elems[idx_list_x]
-    u_ref_coll = unique(trans[2] for trans in trans_coll_x)
-    uy_ref_coll = Vector{Pair{UInt64,Vector{UInt64}}}(undef, length(u_ref_coll))
-    for (i, u_ref) in enumerate(u_ref_coll)
-        idx_list_u = searchsorted(trans_coll_x, (x_ref, u_ref), by = x -> x[2])
-        uy_ref_coll[i] = u_ref => [trans_coll_x[idx][3] for idx in idx_list_u]
+    uy_ref_coll = Pair{UInt64,Vector{UInt64}}[]
+    cur_u = nothing
+    cur_i = 0
+    for i in idx_list_x
+        _, u, y = trans_map.elems[i]
+        if cur_u === nothing || cur_u != u
+            if cur_u !== nothing
+                push!(uy_ref_coll, cur_u => UInt64[trans_map.elems[j][3] for j in cur_i:i])
+            end
+            cur_u = u
+            cur_i = i
+        end
     end
     return uy_ref_coll
 end


### PR DESCRIPTION
For the benchmark of https://github.com/blegat/Dionysos.jl/pull/9, applying this patch on https://github.com/blegat/Dionysos.jl/pull/9, I get:
```
julia> path_planning(4.0, η = 0.2, nsteps=100, plot=false)
set_transitions_from_controlsystem! started
set_transitions_from_controlsystem! terminated with success: 11839413 transitions created
 10.580370 seconds (79.63 M allocations: 3.635 GiB, 5.54% gc time)
set_controller_reach! started
set_controller_reach! terminated without covering init set
  7.830743 seconds (46.53 M allocations: 4.628 GiB, 7.29% gc time)
```