### PR TITLE
Type stable data structure

### DIFF
--- a/src/abstraction.jl
+++ b/src/abstraction.jl
@@ -21,20 +21,20 @@ struct SubSetHash{N} <: SubSet{N}
     elems::Set{UInt64}
 end
 
-struct ControlSystem{N}
+struct ControlSystem{N, Fsys<:Function, Fbound<:Function}
     tstep::Float64
     sys_noise::NTuple{N, Float64}
     meas_noise::NTuple{N, Float64}
-    sys_map::Function
-    bound_map::Function
+    sys_map::Fsys
+    bound_map::Fbound
 end
 
 abstract type SymbolicModel end
 
-mutable struct SymbolicModelHash <: SymbolicModel
-    X_grid::GridSpaceHash
-    U_grid::GridSpaceHash
-    Y_grid::GridSpaceHash
+mutable struct SymbolicModelHash{N1, N2, N3} <: SymbolicModel
+    X_grid::GridSpaceHash{N1}
+    U_grid::GridSpaceHash{N2}
+    Y_grid::GridSpaceHash{N3}
     elems::Vector{Tuple{UInt64, UInt64, UInt64}}
     issorted::Bool
     isunique::Bool


### PR DESCRIPTION
Before this PR, Julia was not able to infer the return types of `sys.sys_map(...)`, `sys.bound_map(...)` and anything that comes out of the grids of a symbolic models as it does not know the length of the tuples.
After this PR, `@code_warntype AB.set_symmodel_from_controlsystem!(trans_map_sys, cont_sys)` shows no red and I have
```
julia> include("examples/example_pathplanning-simple.jl")
set_symmodel_from_controlsystem! started
set_symmodel_from_controlsystem! terminated with success: 11839413 transitions created
  5.483441 seconds (10.29 M allocations: 1.056 GiB, 3.59% gc time)
set_controller_reach! started
..............................................................................................................
set_controller_reach! terminated with success
  6.334167 seconds (347.95 k allocations: 158.896 MiB)
```
and
```
julia> include("examples/example_pathplanning-hard.jl")
set_symmodel_from_controlsystem! started
set_symmodel_from_controlsystem! terminated with success: 21661824 transitions created
 11.471324 seconds (20.26 M allocations: 1.770 GiB, 2.59% gc time)
set_controller_reach! started
........................................................................................................................................................................................................................................................................................................................................................................................................................
set_controller_reach! terminated with success
 57.465402 seconds (377.11 k allocations: 275.551 MiB, 0.04% gc time)
```