### PR TITLE
Get rid of allocations used by generator

### DIFF
--- a/src/gridspace.jl
+++ b/src/gridspace.jl
@@ -100,6 +100,8 @@ function remove_from_gridspace!(grid_space, rect::HyperRectangle, incl_mode::INC
     end
 end
 
+has_pos(grid_space::GridSpaceHash, pos) = haskey(grid_space.elems, hash(pos))
+
 function get_ref_by_pos(grid_space::GridSpaceHash, pos)
     return getkey(grid_space.elems, hash(pos), grid_space.overflow_ref)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -17,12 +17,11 @@ function set_symmodel_from_controlsystem!(sym_model, cont_sys)
 			x = cont_sys.sys_map(x, u, tstep)
             rectI = get_pos_lims_outer(X_grid, HyperRectangle(x .- r, x .+ r))
 		    ypos_iter = Iterators.product(_ranges(rectI)...)
-			yref_iter = (get_ref_by_pos(X_grid, y_pos) for y_pos in ypos_iter)
-			if any(yref_iter .=== X_grid.overflow_ref)
+			if any(y_pos -> !has_pos(X_grid, y_pos), ypos_iter)
 				continue
 			end
-			add_to_symmodel_by_new_refs_coll!(sym_model, (x_rp[1], u_rp[1], y_ref) for y_ref in yref_iter)
-			n_trans += length(yref_iter)
+			add_to_symmodel_by_new_refs_coll!(sym_model, (x_rp[1], u_rp[1], get_ref_by_pos(X_grid, y_pos)) for y_pos in ypos_iter)
+			n_trans += length(ypos_iter)
         end
     end
 	println("set_symmodel_from_controlsystem! terminated with success: $(n_trans) transitions created")


### PR DESCRIPTION
As the function given to the generator is not `isbits`, creating a `Base.Generator` does allocate. Moreover, `any(.. .== ..)` was also allocating the result of `.. .== ..`. With the following changes, we go down to
```
set_symmodel_from_controlsystem! started
set_symmodel_from_controlsystem! terminated with success: 11839413 transitions created
  4.322723 seconds (4.75 M allocations: 573.288 MiB, 3.38% gc time)
set_controller_reach! started
..............................................................................................................
set_controller_reach! terminated with success
  6.582910 seconds (347.95 k allocations: 158.895 MiB, 1.12% gc time)
```
and
```
set_symmodel_from_controlsystem! started
set_symmodel_from_controlsystem! terminated with success: 21661824 transitions created
  8.945490 seconds (8.68 M allocations: 903.715 MiB, 2.71% gc time)
set_controller_reach! started
........................................................................................................................................................................................................................................................................................................................................................................................................................
set_controller_reach! terminated with success
 52.333111 seconds (377.13 k allocations: 275.556 MiB)
```
to be compared to the timings given in https://github.com/blegat/Dionysos.jl/pull/15