### PR TITLE
Improve performance of reach

### DIFF
--- a/src/automaton.jl
+++ b/src/automaton.jl
@@ -51,6 +51,14 @@ function compute_post!(targetlist, autom::AutomatonList, source, symbol)
     end
 end
 
+drop_target(target_source_symbol) = (target_source_symbol[2], target_source_symbol[3])
+function pre(autom::AutomatonList, target)
+    ensure_sorted!(autom)
+    idxlist = searchsorted(autom.transitions, (target,), by = x -> x[1])
+    return Base.Generator(drop_target, view(autom.transitions, idxlist))
+end
+
+# TODO remove
 function compute_pre!(soursymblist, autom::AutomatonList, target)
     ensure_sorted!(autom)
     idxlist = searchsorted(autom.transitions, (target,), by = x -> x[1])


### PR DESCRIPTION
Before:
```julia
julia> include("examples/example_pathplanninglinearized-hard.jl")
...
  0.955527 seconds (63 allocations: 25.924 MiB)
```
After:
```julia
julia> include("examples/example_pathplanninglinearized-hard.jl")
...
  0.768116 seconds (44 allocations: 25.892 MiB)
```
Note that the controller only record the first working control while before this PR, it was recording all the working control at the same distance of the target set. @guberger is that preferred ? If yes, we can recover this feature. With BDD's we can either record all the control at the same distance or record all the control at any distance.