### PR TITLE
Count number of nodes

### DIFF
--- a/test/gol_lazar_belta.jl
+++ b/test/gol_lazar_belta.jl
@@ -45,7 +45,7 @@ using Dionysos
         # Pavito does not support indicator constraints yet so we use `false` here
         @testset "$(typeof(algo))" for algo in [
             BemporadMorari(qp_solver, miqp_solver, false, 0),
-            BranchAndBound(qp_solver, miqp_solver, max_iter = 4000)
+            BranchAndBound(qp_solver, miqp_solver, max_iter = 1111)
         ]
             @testset "Depth: 0" begin
             _test(algo, 0, 18, [0.0, 1.0], nothing, nothing, nothing, true, false)


### PR DESCRIPTION
The number of nodes to explore is actually quite easy to precompute with Dynamic Programming.
This PR counts the number of nodes, then use it to prune paths which are known not to be able to reach the target.
It also check lower vs upper bounds before adding to avoid having to prune them later.
This results in more informative log and faster convergence.